### PR TITLE
Make sure UTF8 encoding when writing subtitle file

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ class Subtitle(object):
             video_id=video_id,
             format=format
         )
-        return open(filename, mode='w+')
+        return open(filename, mode='w+', encoding='UTF8')
 
     def __init__(self, video_id, format):
         self.file = self.new_file(video_id, format)


### PR DESCRIPTION
If computer's default encoding is not utf8, some utf8 strings may fail to save.
this pr fixes it by setting encoding to utf8.