### PR TITLE
Expand configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To override default options, run `python -m tcd --generate-config` and edit gene
 | —.enabled | *bool* | `--[no-]dynamic-duration` | Enable or disable this function. |
 | —.max | *int* | `--dynamic-duration-max` | Maximum duration of subtitle message. |
 | —.max_length | *int* | `--dynamic-duration-max-length` | Maximum length of subtitle message. |
+| millisecond_separator | *str* | `--millisecond-separator` | Separator between seconds and milliseconds in timestamps (IRC only). |
 | group_repeating_emotes | *obj* |  | Convert `Kappa Kappa Kappa` to `Kappa x3`. |
 | —.enabled | *bool* | `--[no-]group` | Enable or disable this function. |
 | —.threshold | *int* | `--group-threshold` | Number of repeating emotes to trigger this function. |

--- a/tcd/__init__.py
+++ b/tcd/__init__.py
@@ -14,8 +14,9 @@ def generate_config():
 
 
 def download(video):
-    writer = SubtitleWriter(video)
-    for comment in Messages(video):
+    messages = Messages(video)
+    writer = SubtitleWriter(messages)
+    for comment in messages:
         writer.add(comment)
     writer.close()
 

--- a/tcd/example.settings.json
+++ b/tcd/example.settings.json
@@ -18,6 +18,8 @@
     "max_length": 100
   },
 
+  "millisecond_separator": ",",
+
   "ssa_style_format": "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding",
   "ssa_style_default": "Style: Default,Arial,20,16777215,16777215,16777215,-2147483640,-1,0,1,3,0,1,5,0,5,0,0",
   "ssa_events_format": "Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",

--- a/tcd/settings.py
+++ b/tcd/settings.py
@@ -102,7 +102,7 @@ def _post_init_parser(help=False):
         '--filename-format', metavar='FORMAT', type=str,
         default=settings['filename_format'],
         help=('Python str.format for generating output file names. Available '
-              'variables: {directory}, {video_id} and {format}.'))
+              'variables: {directory}, {video_id}, {format}, {user_name}, {title}, and {created_at}.'))
     settings_group.add_argument(
         '--max-width', metavar='chars', type=int,
         default=settings['max_width'],

--- a/tcd/settings.py
+++ b/tcd/settings.py
@@ -11,9 +11,16 @@ from argparse import ArgumentParser
 SELF = inspect.getfile(inspect.currentframe())
 ROOT = os.path.dirname(os.path.abspath(SELF))
 
-settings_file_default = 'settings.json'
-if not os.path.isfile(settings_file_default):
-    settings_file_default = ROOT + '/example.settings.json'
+settings_filename = 'settings.json'
+home_settings_path = os.path.join(os.path.expanduser('~'), '.config/tcd', settings_filename)
+example_settings_path = os.path.join(ROOT, f'example.{settings_filename}')
+
+if os.path.isfile(settings_filename):
+    settings_file_default = settings_filename
+elif os.path.isfile(home_settings_path):
+    settings_file_default = home_settings_path
+else:
+    settings_file_default = example_settings_path
 
 
 def _pre_init_parser(help=False):

--- a/tcd/settings.py
+++ b/tcd/settings.py
@@ -46,6 +46,8 @@ if settings['version'].startswith("1"):
           "(see example.settings.json for examples)")
     sys.exit(1)
 
+if 'millisecond_separator' not in settings:
+    settings['millisecond_separator'] = ','
 if 'group_repeating_emotes' not in settings:
     settings['group_repeating_emotes'] = {'enabled': False,
                                           'threshold': 3,
@@ -102,7 +104,8 @@ def _post_init_parser(help=False):
         '--filename-format', metavar='FORMAT', type=str,
         default=settings['filename_format'],
         help=('Python str.format for generating output file names. Available '
-              'variables: {directory}, {video_id}, {format}, {user_name}, {title}, and {created_at}.'))
+              'variables: {directory}, {video_id}, {format}, {user_name}, '
+              '{title}, and {created_at}.'))
     settings_group.add_argument(
         '--max-width', metavar='chars', type=int,
         default=settings['max_width'],

--- a/tcd/settings.py
+++ b/tcd/settings.py
@@ -128,6 +128,10 @@ def _post_init_parser(help=False):
         '--dynamic-duration-max-length', metavar='chars', type=int,
         default=settings['dynamic_duration']['max_length'],
         help='Maximum length of subtitle message.')
+    settings_group.add_argument(
+        '--millisecond-separator', metavar='FORMAT', type=str,
+        default=settings['millisecond_separator'],
+        help='Separator between seconds and milliseconds in timestamps.')
 
     group = settings_group.add_mutually_exclusive_group(required=False)
     group.add_argument(
@@ -191,6 +195,7 @@ settings['subtitle_duration'] = args.subtitle_duration
 settings['dynamic_duration']['enabled'] = args.dynamic
 settings['dynamic_duration']['max'] = args.dynamic_duration_max
 settings['dynamic_duration']['max_length'] = args.dynamic_duration_max_length
+settings['millisecond_separator'] = args.millisecond_separator
 settings['group_repeating_emotes']['enabled'] = args.group
 settings['group_repeating_emotes']['threshold'] = args.group_threshold
 settings['group_repeating_emotes']['collocations'] = args.group_collocations

--- a/tcd/subtitles.py
+++ b/tcd/subtitles.py
@@ -22,9 +22,6 @@ def clean_filename(string, valid_filename_regex=re.compile(r'(?u)[^-\w.()\[\]{}@
 class Subtitle(object):
     @staticmethod
     def new_file(video_id, format):
-        if not os.path.exists(settings['directory']):
-            os.makedirs(settings['directory'])
-
         video_info = gql(f'''
             query {{
                 video(id: {video_id}) {{
@@ -49,6 +46,9 @@ class Subtitle(object):
             title=clean_filename(video_info['data']['video']['title']),
             created_at=clean_filename(time_str)
         )
+
+        if not os.path.exists(os.path.dirname(filename)):
+            os.makedirs(os.path.dirname(filename))
 
         return io.open(filename, mode='w+', encoding='UTF8')
 

--- a/tcd/subtitles.py
+++ b/tcd/subtitles.py
@@ -172,7 +172,7 @@ class SubtitlesIRC(Subtitle):
 
     @staticmethod
     def ftime(seconds):
-        return Subtitle.ftime(seconds)[:-3].replace('.', ',')
+        return Subtitle.ftime(seconds)[:-3].replace('.', settings['millisecond_separator'])
 
     def add(self, comment):
         self.file.write("[{start}] <{user}> {message}\n".format(

--- a/tcd/twitch.py
+++ b/tcd/twitch.py
@@ -108,14 +108,22 @@ class Messages(object):
         video = gql(f'''
             query {{
                 video(id: {video_id}) {{
+                    creator {{
+                        displayName
+                        id
+                    }}
                     createdAt
                     lengthSeconds
+                    title
                 }}
             }}
         ''')
 
         self.created_at = parse8601(video['data']['video']['createdAt'])
         self.duration = video['data']['video']['lengthSeconds']
+        self.title = video['data']['video']['title']
+        self.creator_name = video['data']['video']['creator']['displayName']
+        self.creator_id = video['data']['video']['creator']['id']
 
         if settings.get('display_progress') in [None, True]:
             self.progressbar = ProgressBar(max_value=self.duration)

--- a/tcd/twitch.py
+++ b/tcd/twitch.py
@@ -108,22 +108,14 @@ class Messages(object):
         video = gql(f'''
             query {{
                 video(id: {video_id}) {{
-                    creator {{
-                        displayName
-                        id
-                    }}
                     createdAt
                     lengthSeconds
-                    title
                 }}
             }}
         ''')
 
         self.created_at = parse8601(video['data']['video']['createdAt'])
         self.duration = video['data']['video']['lengthSeconds']
-        self.title = video['data']['video']['title']
-        self.creator_name = video['data']['video']['creator']['displayName']
-        self.creator_id = video['data']['video']['creator']['id']
 
         if settings.get('display_progress') in [None, True]:
             self.progressbar = ProgressBar(max_value=self.duration)


### PR DESCRIPTION
Hey, I added some features that improve configurability. These specific additions are:

- Will check for a settings.json in ~/.config/tcd/ if it isn't present in the current working directory. If it still can't find a settings.json, then it will use the example settings file.
- Added `{user_name}` (broadcaster's display name), `{title}`, and `{created_at}` options to the filename format. I also intended to make the `{created_at}` datetime format configurable, but that may be a bit tricky so I left it with a default format only for now.
- Added millisecond_separator setting to choose the character(s) used to separate seconds and milliseconds in IRC timestamps. I noticed that you purposefully replaced the full-stop separator with a comma, but I thought it'd be nice if this could be user-configurable.
https://github.com/TheDrHax/Twitch-Chat-Downloader/blob/a3731ed46259f3e2f8a03d742479e0b97f921172/tcd/subtitles.py#L148-L149