### PR TITLE
Ensure that logged badges have the same ordering as the badge map

### DIFF
--- a/tcd/twitch.py
+++ b/tcd/twitch.py
@@ -77,6 +77,11 @@ class Message(object):
 
         return ' '.join(words)
 
+    @staticmethod
+    def sort_badges(badge, badge_map_vals):
+        return (badge not in badge_map_vals,
+                list(badge_map_vals).index(badge) if badge in badge_map_vals else False)
+
     def __init__(self, comment):
         self.user = comment['commenter']['displayName']
 
@@ -88,7 +93,9 @@ class Message(object):
             max_count = settings['badges']['max_count']
             if max_count >= 1:
                 if len(badges) > max_count:
-                    badges = badges[0:max_count]
+                    sorted_badges = sorted(
+                        badges, key=lambda b: self.sort_badges(b, settings['badges']['map'].values()))
+                    badges = sorted_badges[0:max_count]
 
             self.badge = ''.join(badges)
         else:


### PR DESCRIPTION
I probably should have clarified why I used the below structure when selecting a single badge. I did it this way to ensure that it would follow the order of the badge mapping from settings.conf. For example, admins are higher in the mapping than subscribers, since knowing someone is an admin is more important than knowing they're a subscriber.

This commits re-adds the badge-ordering functionality while keeping your structural changes intact. It also has the added benefit of ordering multiple badges, instead of just picking the first badge with the highest priority. Feel free to change the style to be consistent with your own, but please preserve the badge-ordering functionality.

https://github.com/TheDrHax/Twitch-Chat-Downloader/blob/16f29f1132f4d9799fef809b935c22da20152c8d/tcd/twitch.py#L92-L95