### PR TITLE
Fix linting error with urllib3 import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 progressbar2
 iso8601
+urllib3

--- a/tcd/twitch.py
+++ b/tcd/twitch.py
@@ -3,7 +3,7 @@ from iso8601 import parse_date as parse8601
 from progressbar import ProgressBar
 from requests import Session
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3 import Retry
+from urllib3 import Retry
 
 from .settings import settings
 


### PR DESCRIPTION
This commit shouldn't change any functionality, it just switches from importing `Retry` via requests to importing it directly through urllib3. I did this because my linter was giving me a headache about the import not resolving, and it's good practice to import directly from a package, rather than going through a different package first.

I also explicitly added urllib3 to requirements.txt, though this shouldn't change functionality either. Even through urllib3 will always be installed since it's a dependency of requests, it's a good practice to put all the packages you import from into requirements.txt.

Relevant issues addressing linting problem:
https://github.com/python/typeshed/issues/6893
https://youtrack.jetbrains.com/issue/PY-53895
https://stackoverflow.com/a/68281646