### PR TITLE
Fix сlient_id in settings

### DIFF
--- a/tcd/example.settings.json
+++ b/tcd/example.settings.json
@@ -1,7 +1,7 @@
 {
   "version": "2.4.4",
 
-  "client_id": "jzkbprff40iqj646a697cyrvl0zt2m6",
+  "client_id": "kd1unb4b3q4t58fwlpcbzcbnm76a8fp",
   "cooldown": 0,
   "display_progress": true,
 


### PR DESCRIPTION
It looks like the "client id" being used no longer works. I changed it to a new one, which I took from the [TwitchDownloader](https://github.com/lay295/TwitchDownloader) project: [https://github.com/lay295/TwitchDownloader/blob/3a844c2b37d10c626a494885ee90897024002b67/TwitchDownloaderCore/ChatDownloader.cs#L27](https://github.com/lay295/TwitchDownloader/blob/3a844c2b37d10c626a494885ee90897024002b67/TwitchDownloaderCore/ChatDownloader.cs#L27)